### PR TITLE
Add aggregate function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ fabric.properties
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 
+.idea/

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
 }
 
 dependencies {
-    compile group: 'com.google.guava', name: 'guava', version: '19.0'
+    compile group: 'com.google.guava', name: 'guava', version: '21.0'
     compile group: 'postgresql', name: 'postgresql', version: '9.0-801.jdbc4'
 }
 

--- a/src/main/java/edu/cmu/cs/db/peloton/test/common/AggregateType.java
+++ b/src/main/java/edu/cmu/cs/db/peloton/test/common/AggregateType.java
@@ -1,0 +1,12 @@
+package edu.cmu.cs.db.peloton.test.common;
+
+/**
+ * Aggregate function type.
+ */
+public enum AggregateType {
+    SUM,
+    AVG,
+    MIN,
+    MAX,
+    COUNT
+}

--- a/src/main/java/edu/cmu/cs/db/peloton/test/generate/defn/AggregateFunc.java
+++ b/src/main/java/edu/cmu/cs/db/peloton/test/generate/defn/AggregateFunc.java
@@ -1,0 +1,63 @@
+package edu.cmu.cs.db.peloton.test.generate.defn;
+
+import edu.cmu.cs.db.peloton.test.common.AggregateType;
+import edu.cmu.cs.db.peloton.test.common.DatabaseDefinition;
+import edu.cmu.cs.db.peloton.test.generate.Context;
+import edu.cmu.cs.db.peloton.test.generate.Iterators;
+import edu.cmu.cs.db.peloton.test.generate.ast.Ast;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Objects;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Aggregate functions for SELECT statement.
+ */
+public class AggregateFunc implements Ast.Elem {
+
+    private final Ast.Elem prop;
+
+    AggregateFunc(Ast.Elem prop) {
+        checkNotNull(prop);
+        this.prop = prop;
+    }
+
+    @Override
+    public Iterator<Ast.Clause> allClauses(DatabaseDefinition db, Context context, int depth) {
+        Iterator<Ast.Clause> res = Collections.emptyIterator();
+        Iterator<Ast.Clause> clauses = prop.allClauses(db, context, depth);
+        while(clauses.hasNext()) {
+            String clause = clauses.next().getClause();
+            res = Iterators.chain(res, getAggregateProps(db, context, clause));
+        }
+        return res;
+    }
+
+    private static Iterator<Ast.Clause> getAggregateProps(DatabaseDefinition db,
+                                                          Context context,
+                                                          String clause) {
+        return Arrays.stream(AggregateType.values())
+                .map(type -> applyAggregateFunc(db, type, clause))
+                .filter(Objects::nonNull)
+                .map(a -> new Ast.Clause(a, context))
+                .iterator();
+    }
+
+    /**
+     * Apply a aggregate function to a clause.
+     * Return null is not applicable.
+     *
+     * TODO: check if aggregate function is applicable to the clause column type
+     * EG: AVG, SUM can only be applied to numeric type
+     *     MIN, MAX : numeric type + date/time
+     *     COUNT can be applied to everything (basic types, *)
+     */
+    private static String applyAggregateFunc(DatabaseDefinition db,
+                                             AggregateType type,
+                                             String clause) {
+        return type + "(" + clause + ")";
+    }
+}

--- a/src/main/java/edu/cmu/cs/db/peloton/test/generate/defn/SelectProp.java
+++ b/src/main/java/edu/cmu/cs/db/peloton/test/generate/defn/SelectProp.java
@@ -5,16 +5,40 @@ import edu.cmu.cs.db.peloton.test.generate.ast.Ast;
 import edu.cmu.cs.db.peloton.test.generate.ast.ListElem;
 import edu.cmu.cs.db.peloton.test.generate.ast.SumElem;
 
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
+
 /**
- * Created by tianyuli on 3/20/17.
+ * SelectProp - SQL SELECT statement.
+ * baseProp:
+ *  - table_name.column_name
+ *  - table_name.*
+ *  - *
+ * aggregateProp:
+ *  - aggregate_function(prop)
+ *
+ * Not supporting (yet):
+ * - AS
+ * - DISTINCT
+ * - CONCAT
  */
 public class SelectProp extends SumElem {
     @Override
     protected ImmutableList<Ast.Elem> args() {
-        return ImmutableList.of(
+        ImmutableList<Ast.Elem> baseProps = ImmutableList.of(
                 new ListElem(new PropertySpec()),
                 new ListElem(new ClassAliasStar()),
                 new Star()
         );
+
+        List<Ast.Elem> aggregateProps = baseProps.stream()
+                .map(prop -> new ListElem(new AggregateFunc(prop)))
+                .collect(Collectors.toList());
+
+        return new ImmutableList.Builder<Ast.Elem>()
+                .addAll(baseProps)
+                .addAll(aggregateProps)
+                .build();
     }
 }

--- a/src/main/java/edu/cmu/cs/db/peloton/test/generate/defn/SimpleSelect.java
+++ b/src/main/java/edu/cmu/cs/db/peloton/test/generate/defn/SimpleSelect.java
@@ -19,6 +19,6 @@ public class SimpleSelect extends ProductElem {
 
     @Override
     protected String format(List<String> args) {
-        return String.format("SELECT %s FROM %s", args.get(1), args.get(0));
+        return String.format("SELECT %s FROM %s;", args.get(1), args.get(0));
     }
 }


### PR DESCRIPTION
This PR:
1. Update Guava
2. Add ';' at the end of simple select stmt
3. Add aggregate function

Right now it will generate things like this:
`SELECT SUM(*),AVG(*),MIN(*),MAX(*),COUNT(*) FROM test;`
`SELECT MAX(test.id),COUNT(test.id),SUM(test.name),AVG(test.name),MIN(test.name),MAX(test.name),COUNT(test.name),SUM(test.id,test.name),AVG(test.id,test.name),MIN(test.id,test.name),MAX(test.id,test.name),COUNT(test.id,test.name) FROM test;
`
Will add more constraints and structures when applying aggregate function in the future. 

