### PR TITLE
setupTrace feature addition

### DIFF
--- a/dbSetupTrace
+++ b/dbSetupTrace
@@ -1,0 +1,3 @@
+DROP TABLE IF EXISTS foobar;
+CREATE TABLE foobar( field1 int, field2 int, field3 int);
+INSERT INTO foobar VALUES (12, 30, 45), (10, 20, 25), (15, 40, 35);

--- a/dbTrace
+++ b/dbTrace
@@ -1,3 +1,4 @@
 SELECT * FROM foo
 SELECT * FROM bar
 SELECT * FROM foo
+SELECT * FROM foobar;

--- a/src/main/java/edu/cmu/cs/db/peloton/test/app/Args.java
+++ b/src/main/java/edu/cmu/cs/db/peloton/test/app/Args.java
@@ -15,6 +15,10 @@ public class Args {
             description = "path to trace file with one query per line to execute")
     private String traceFile;
 
+    @Parameter(names = "-setupTrace",
+            description = "path to a trace file with CREATE/INSERT/UPDATE queries to initialize table contents")
+    private String setupTraceFile;
+
     @Parameter(names = "-out",
             description = "path to output dir, if empty then just print to command line")
     private String outDir;
@@ -32,6 +36,10 @@ public class Args {
 
     public String getTraceFile() {
         return traceFile;
+    }
+
+    public String getSetupTraceFile() {
+        return setupTraceFile;
     }
 
     public String getOutDir() {

--- a/src/main/java/edu/cmu/cs/db/peloton/test/app/Main.java
+++ b/src/main/java/edu/cmu/cs/db/peloton/test/app/Main.java
@@ -39,6 +39,8 @@ public class Main {
             truthDb = new DatabaseWrapper(config.readLine(), config.readLine(), config.readLine());
         }
 
+        TestInitialization.runSetupTraceIfExists(parsedArgs.getSetupTraceFile());
+
         batchSize = parsedArgs.getBatchSize();
         queryProvider = parsedArgs.getTraceFile() == null
                 ? Iterators.fromAst(new Select(), parsedArgs.getLimit(),truthDb.getDatabaseDefinition(), new Random())

--- a/src/main/java/edu/cmu/cs/db/peloton/test/app/TestInitialization.java
+++ b/src/main/java/edu/cmu/cs/db/peloton/test/app/TestInitialization.java
@@ -21,6 +21,7 @@ public class TestInitialization {
      */
     public static void runSetupTraceIfExists(String setupTraceFile)
         throws SQLException, IOException {
+        if(setupTraceFile == null) return;
         try (BufferedReader setupTrace = new BufferedReader(new FileReader(setupTraceFile))) {
             String query;
             while ((query = setupTrace.readLine()) != null) {

--- a/src/main/java/edu/cmu/cs/db/peloton/test/app/TestInitialization.java
+++ b/src/main/java/edu/cmu/cs/db/peloton/test/app/TestInitialization.java
@@ -1,7 +1,40 @@
 package edu.cmu.cs.db.peloton.test.app;
 
+import java.io.BufferedReader;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
+import java.sql.SQLException;
+
 /**
  * Created by tianyuli on 5/7/17.
  */
 public class TestInitialization {
+
+    /**
+     * Given a setup/initialization trace file via the 'setup_trace' optional argument
+     * this function runs all DDL/Insert/Update/Delete statements to build the table.
+     * Alternatively, an option to randomly create/populate tables will be added in
+     * future versions. Any 'SELECT' statements will be ignored.
+     * @param setupTraceFile
+     * @throws SQLException
+     */
+    public static void runSetupTraceIfExists(String setupTraceFile)
+        throws SQLException, IOException {
+        try (BufferedReader setupTrace = new BufferedReader(new FileReader(setupTraceFile))) {
+            String query;
+            while ((query = setupTrace.readLine()) != null) {
+                if (isValidQuery(query)) {
+                    Main.testDb.getConnection().createStatement().executeUpdate(query);
+                    Main.truthDb.getConnection().createStatement().executeUpdate(query);
+                }
+            }
+        }
+    }
+
+    public static boolean isValidQuery(String query) {
+        return query.length() != 0 && !query.toUpperCase().startsWith("SELECT");
+    }
+
+
 }


### PR DESCRIPTION
The idea is that before we start generating queries or executing traces we may want to populate the two databases first.

Basically adding the -setupTrace <dbSetupTrace> with a file like the one in this PR(dbSetupTrace) with DDL/INSERT/UPDATE statements, executes the queries in this file in both databases to populate the relevant tables.